### PR TITLE
Fix charset when generating config XML

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/GoFileConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoFileConfigDataSource.java
@@ -403,8 +403,8 @@ public class GoFileConfigDataSource {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         magicalGoConfigXmlWriter.write(config, outputStream, skipPreprocessingAndValidation);
         LOGGER.debug("[Config Save] === Done converting config to XML");
-        // FIXME The below using default charset seems like a bug
-        return outputStream.toString(Charset.defaultCharset());
+        // The config xml is always written using UTF-8
+        return outputStream.toString(StandardCharsets.UTF_8);
     }
 
     public String getFileLocation() {


### PR DESCRIPTION
## Summary
- avoid using platform default charset when converting config XML to a string

## Testing
- `./gradlew test` *(fails: No route to host when downloading gradle)*